### PR TITLE
Change peserta flash message wording

### DIFF
--- a/app/Http/Controllers/PesertaController.php
+++ b/app/Http/Controllers/PesertaController.php
@@ -107,7 +107,7 @@ class PesertaController extends Controller
 
 
             // Berikan pesan sukses setelah update
-            Session::flash('message', "Juri dengan Nomor Induk: ({$user->username}) berhasil diperbarui.");
+            Session::flash('message', "Peserta dengan Nomor Induk: ({$user->username}) berhasil diperbarui.");
             return redirect()->back();
         } catch (\Exception $e) {
             // Tangani error jika terjadi kesalahan saat menyimpan


### PR DESCRIPTION
## Summary
- fix flash message when updating peserta to reference `Peserta` instead of `Juri`

## Testing
- `composer install --no-interaction --no-progress` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_b_687b562de3b4832691864960dbb66336